### PR TITLE
Fix variant filtering to correctly exclude masked bases in vcf

### DIFF
--- a/coelsch_pipeline/pipeline/rules/variants.snakefile
+++ b/coelsch_pipeline/pipeline/rules/variants.snakefile
@@ -252,7 +252,7 @@ rule filter_msyd_snps_for_star_consensus:
           {params.blacklist_flag} |
         bcftools view -G
           -e "STRLEN(REF)>{params.max_indel_size} || STRLEN(ALT)>{params.max_indel_size}" |
-        awk '$0 ~ /^##/ || $4 !~ /[acgtryswkmbdhvnSWKMBDHVN]/ || $5 !~ /[acgtryswkmbdhvnSWKMBDHVN]/' |
+        awk '$0 ~ /^#/ || ($4 ~ /^[ACGT]+$/ && $5 ~ /^[ACGT]+$/)' |
         bcftools norm --remove-duplicates 
           -f {input.fasta}
         > {output.vcf};


### PR DESCRIPTION
The previous awk filter used negative regex matching and OR logic which failed to catch all masked variants.

changes:
- use positive matching: only keep variants where REF and ALT are uppercase ACGT
- use && instead of ||: ensure both REF and ALT only contain allowed bases

This ensures masked variants are properly excluded from the vcf files used for STAR consensus alignment.