### PR TITLE
Add notebook template rendering step (Jinja2 markdown rendering)

### DIFF
--- a/coelsch_pipeline/pipeline/notebook_templates/haplotyping_report.py.ipynb
+++ b/coelsch_pipeline/pipeline/notebook_templates/haplotyping_report.py.ipynb
@@ -30,7 +30,7 @@
    "id": "6b38ea33",
    "metadata": {},
    "source": [
-    "### Report for analysis of {{ snakemake.wildcards[\"dataset_name_plus_optional_haplo\"] }}"
+    "### Report for analysis of {{ wildcards[\"dataset_name\"] }}"
    ]
   },
   {
@@ -78,7 +78,7 @@
    "source": [
     "## Number of informative reads\n",
     "\n",
-    "The number of reads that distinguish haplotypes is dependent on the sequencing stragety, library complexity, and sequencing depth, as well as the number of (mappable) SNPs that actually distinguish the two haplotypes. This dataset has already been filtered to remove barcodes with fewer than {{ snakemake.config[\"haplotyping\"][\"preprocessing\"][\"min_informative_reads_per_barcode\"] }} informative reads."
+    "The number of reads that distinguish haplotypes is dependent on the sequencing stragety, library complexity, and sequencing depth, as well as the number of (mappable) SNPs that actually distinguish the two haplotypes. This dataset has already been filtered to remove barcodes with fewer than {{ config[\"haplotyping\"][\"preprocessing\"][\"min_informative_reads_per_barcode\"] }} informative reads."
    ]
   },
   {
@@ -97,7 +97,7 @@
     "plt.xscale('log')\n",
     "ax.set_xlabel('Number of informative reads (log10 scale)')\n",
     "ax.set_ylabel('Number of barcodes/samples')\n",
-    "ax.set_title(f'{snakemake.wildcards.dataset_name_plus_optional_haplo} informative read distribution')\n",
+    "ax.set_title(f'{snakemake.wildcards.dataset_name} informative read distribution')\n",
     "plt.show()"
    ]
   },
@@ -246,7 +246,7 @@
     "ax.hist(cb_stats_filt.n_crossovers, bins=20)\n",
     "ax.set_xlabel('Estimated crossovers')\n",
     "ax.set_ylabel('Number of barcodes/samples')\n",
-    "ax.set_title(f'{snakemake.wildcards.dataset_name_plus_optional_haplo} estimated crossover numbers')\n",
+    "ax.set_title(f'{snakemake.wildcards.dataset_name} estimated crossover numbers')\n",
     "plt.show()\n",
     "\n",
     "haplotypes_filt.plot_recombination_landscape(co_markers=markers_filt)\n",

--- a/coelsch_pipeline/pipeline/rules/align_common.snakefile
+++ b/coelsch_pipeline/pipeline/rules/align_common.snakefile
@@ -83,8 +83,22 @@ def calculate_genome_sa_index_nbases(wc, input):
 
 rule build_STAR_index:
     """
-    Builds a STAR genome index for alignment. Uses either reference genome alone, or in conjunction with a 
-    VCF file to produce a "STAR consensus" variant transformed genome.
+    Build a STAR genome index for alignment, optionally using STAR genome transform.
+
+    Creates a STAR index either from the reference genome alone, or (when ref genotype != qry genotype)
+    from the reference genome plus a per-query VCF to generate a haploid “STAR consensus”
+    transformed genome index.
+
+    Parameters:
+      Defined in config section alignment: star (and uses VCFs produced under variants: star_consensus).
+
+    Inputs:
+      - reference genome fasta (annotations)
+      - reference genome annotation GTF (annotations)
+      - optional query VCF for genome transformation (annotations/vcf/star_consensus)
+
+    Outputs:
+      - STAR genome index directory for the reference × query combination (annotations/star_indexes)
     """
     input:
         unpack(get_star_index_input)

--- a/coelsch_pipeline/pipeline/rules/haplotype.snakefile
+++ b/coelsch_pipeline/pipeline/rules/haplotype.snakefile
@@ -407,9 +407,6 @@ rule haplotyping_report:
     Runs a notebook template that consumes the marker JSONs, predictions, and stats
     from `run_haplotyping` and produces a rendered analysis notebook for inspection.
 
-    Parameters:
-      Notebook template is fixed in the rule; execution environment defined by the coelsch conda env.
-
     Inputs:
       - Coelsch marker JSONs, predictions, and stats (results/haplotypes)
 
@@ -427,4 +424,4 @@ rule haplotyping_report:
     conda:
         get_conda_env('coelsch')
     notebook:
-        lambda wc: results(f'analysis/{wc.dataset_name}.haplotyping_report.template.py.ipynb')
+        results('analysis/{dataset_name}.haplotyping_report.template.py.ipynb')

--- a/coelsch_pipeline/pipeline/rules/notebook.snakefile
+++ b/coelsch_pipeline/pipeline/rules/notebook.snakefile
@@ -1,0 +1,68 @@
+rule render_notebook_template:
+    """
+    Render Jinja2 templating in a notebook template (markdown cells only).
+
+    Loads a notebook from ../notebook_templates and renders Jinja2 only within
+    markdown cells. The template context exposes workflow values via
+    top-level names (config/input/output/wildcards/params/threads/resources/log)
+
+    Inputs:
+      - notebook template (../notebook_templates)
+
+    Outputs:
+      - rendered notebook (results/analysis)
+    """
+    input:
+        template='../notebook_templates/{notebook_template}.{nb_lang}.ipynb'
+    output:
+        rendered=temp(results('analysis/{dataset_name}.{notebook_template}.template.{nb_lang,py|r}.ipynb'))
+    run:
+        import json
+        from jinja2 import Environment, StrictUndefined
+
+        def _to_native(x):
+            # Convert Snakemake IO/params objects into plain python types for Jinja.
+            if x is None:
+                return None
+            if isinstance(x, (str, int, float, bool)):
+                return x
+            if isinstance(x, dict):
+                return {k: _to_native(v) for k, v in x.items()}
+            if isinstance(x, (list, tuple, set)):
+                return [_to_native(v) for v in x]
+            # Namedlist / IOFile / other path-like objects
+            try:
+                return str(x)
+            except Exception:
+                return x
+
+        # Build a flat context the templates can reference directly.
+        ctx = {
+            "config": config,
+            "wildcards": {k: getattr(wildcards, k) for k in getattr(wildcards, "keys", lambda: [])()},
+            "input": _to_native({k: v for k, v in getattr(input, "items", lambda: [])()}),
+            "output": _to_native({k: v for k, v in getattr(output, "items", lambda: [])()}),
+            "params": _to_native({k: v for k, v in getattr(params, "items", lambda: [])()}),
+            "threads": threads,
+            "resources": _to_native(resources),
+            "log": _to_native({k: v for k, v in getattr(log, "items", lambda: [])()}),
+        }
+
+        env = Environment(undefined=StrictUndefined)
+
+        with open(input.template, "r", encoding="utf-8") as f:
+            nb = json.load(f)
+
+        for cell in nb.get("cells", []):
+            if cell.get("cell_type") != "markdown":
+                continue
+            src = cell.get("source", [])
+            if isinstance(src, list):
+                txt = "".join(src)
+                rendered = env.from_string(txt).render(ctx)
+                cell["source"] = rendered.splitlines(keepends=True)
+            elif isinstance(src, str):
+                cell["source"] = env.from_string(src).render(ctx)
+
+        with open(output.rendered, "w", encoding="utf-8") as f:
+            json.dump(nb, f, ensure_ascii=False, indent=1)


### PR DESCRIPTION
introduces a general notebook rendering rule that applies Jinja2 templating to markdown cells only before notebook execution. The rendered notebook is then used by reporting rules such as haplotyping_report.

So far untested (will see if snakemake is ok with lambdas in notebook blocks. Possibly not...)